### PR TITLE
upgrade to axum 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-tracing"
-version = "0.2.3"
+version = "0.3.0"
 authors = [
     "Fernando Goncalves <fernando.hsgoncalves@gmail.com>",
     "Alefh Sousa <alefh.sousa@gmail.com>",
@@ -28,13 +28,13 @@ axum = [
 ]
 
 [dependencies]
-axum = { version = "^0.7.4", optional = true }
-http = { version = "1.0", optional = true }
+axum = { version = "^0.8", optional = true }
+http = { version = "1", optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 futures-util = { version = "0.3", default-features = false, features = [
 ], optional = true }
-axum-tracing-opentelemetry = { version = "0.16.0", optional = true }
-tracing-opentelemetry-instrumentation-sdk = { version = "0.16.0", optional = true }
+axum-tracing-opentelemetry = { version = "0.25", optional = true }
+tracing-opentelemetry-instrumentation-sdk = { version = "0.16.0", features = ["http"], optional = true }
 tower = { version = "0.4", optional = true }
 chrono = "^0.4.33"
 opentelemetry = { version = "^0.21.0" }
@@ -42,9 +42,9 @@ opentelemetry_sdk = { version = "^0.21.2", features = ["rt-tokio"] }
 opentelemetry-http = { version = "^0.10.0" }
 opentelemetry-datadog = { version = "0.9.0", features = ["reqwest-client"] }
 reqwest = { version = "0.11", default-features = false }
-serde = { version = "^1.0.196", features = ["derive"] }
-serde_json = "^1.0.113"
-tokio = { version = "^1.36.0", features = [
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = [
     "signal",
     "macros",
 ], optional = true }

--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = "^0.7.4"
+axum = "^0.8"
 datadog-tracing = { path = "../..", features = ["axum"] }
-tokio = { version = "^1.36.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.5.1", features = ["timeout"] }
 tracing = "^0.1.40"

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -37,7 +37,7 @@ pub fn build_tracer() -> TraceResult<Tracer> {
         .with_api_version(ApiVersion::Version05)
         .with_agent_endpoint(format!("http://{dd_host}:{dd_port}"))
         .with_trace_config(
-            trace::config()
+            trace::Config::default()
                 .with_sampler(Sampler::AlwaysOn)
                 .with_id_generator(RandomIdGenerator::default()),
         )


### PR DESCRIPTION
## Objective
This is the minimal changeset required to use `datadog-tracing` with `axum` version 0.8 and above.

## Proposed changes
- Increase project version from 0.2.3 to 0.3.0 to signal the breaking change
- Remove all direct dependency on `axum` version 0.7 and also upgrade `axum-tracing-opentelemetry` to the minimal version referring to `axum` version 0.8
- Depend on major versions of stable crates
