### PR TITLE
chore(ci): add Makefile and initial CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: "1.86"
+  RUST_VERSION: "1.86.0"
 
 jobs:
   quality:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: Quality
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: "1.86"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: Quality
+
+on:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_VERSION: "1.86"
+
+jobs:
+  quality:
+    name: Run Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Configure Git to use HTTPS with token
+        run: |
+          git config --global url."https://${{ secrets.WILLBANK_PLATFORMS_PERSONAL_ACCESS_TOKEN }}:@github.com/".insteadOf "https://github.com/"
+
+      - uses: will-bank/rust-setup-action@v1.80
+        with:
+          toolchain: 1.86.0
+          components: clippy, rustfmt
+      
+      - name: Lint
+        run: make lint
+
+      - name: Test and Coverage
+        run: make test_ci

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: lint
+lint:
+	cargo clippy --all-targets --all-features
+
+.PHONY: build
+build:
+	cargo build --all-targets --all-features
+
+.PHONY: lint_fix
+lint_fix:
+	cargo clippy --all-targets --all-features --fix --allow-dirty
+
+.PHONY: format
+format:
+	cargo fmt --all
+
+.PHONY: test
+test:
+	cargo test --all-targets --all-features  -- --nocapture ${NAME}
+
+.PHONY: coverage
+coverage:
+	cargo install cargo-tarpaulin
+	cargo tarpaulin --fail-under 80 --all-targets --all-features --locked --target-dir target/coverage -- --nocapture
+
+.PHONY: test_ci
+test_ci:
+	cargo test --all-targets --all-features  -- --nocapture 


### PR DESCRIPTION
## What was done

- Added a Makefile with essential commands for development and CI: `lint`, `build`, `format`, `test`, `coverage`, and `test_ci`.
- Added a CI workflow in GitHub Actions to automatically run lint and tests on every pull request.

## Benefits

- Facilitates the standardization of development commands.
- Ensures that the code passes automatic lint and test validations before being merged into main.
- Improves the quality and reliability of the project.

## How to test

- The workflow will run automatically when opening or updating a PR.
- You can also run the commands manually using `make <command>`.

---

Any suggestions for improvement are welcome!